### PR TITLE
Added check using cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,19 @@
 SUBDIRS=src docs tests buildutils
 EXTRA_DIST=RELEASE_VERSION
 
+CPPCHECK_CMD=	cppcheck
+CPPCHECK_OPT=	--quiet \
+				--error-exitcode=1 \
+				--inline-suppr \
+				-j 4 \
+				--std=c++03 \
+				--xml \
+				--enable=warning,style,information,missingInclude
+CPPCHECK_IGN=
+
+cppcheck:
+	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
+
 #
 # VIM modelines
 #

--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -39,7 +39,7 @@ func_usage()
 	echo "        -h                 print help"
 	echo "Environments"
 	echo "        BUILD_NUMBER       specify build number for packaging(default 1)"
-	echo "        TRAVIS_TAG         if the current build is for a git tag, this variable is set to the tagÅfs name"
+	echo "        TRAVIS_TAG         if the current build is for a git tag, this variable is set to the tag‚Äôs name"
 	echo "        FORCE_BUILD_PKG    if this env is 'true', force packaging anytime"
 	echo "        USE_PC_REPO        if this env is 'true', use packagecloud.io repository"
 	echo "        CONFIGUREOPT       specify extra configure option."
@@ -321,10 +321,27 @@ else
 	#
 	# Using RHSCL because centos has older ruby
 	#
-	run_cmd yum install -y -qq centos-release-scl
-	run_cmd yum install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
+	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
+	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
 	run_cmd ${GEM_BIN} install rubocop package_cloud
+fi
+
+#
+# For cppcheck
+#
+if [ ${IS_CENTOS} -eq 1 ]; then
+	#
+	# For CentOS, it need to allow EPEL(with setting disable)
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq epel-release
+	run_cmd yum-config-manager --disable epel
+	run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y -qq cppcheck
+else
+	#
+	# Fedora, Ubuntu...
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq cppcheck
 fi
 
 #
@@ -337,6 +354,7 @@ SRCTOP="/tmp/${TMPSRCTOP}"
 run_cmd cd ${SRCTOP}
 run_cmd ./autogen.sh
 run_cmd ./configure --prefix=/usr ${CONFIGUREOPT}
+run_cmd make cppcheck
 run_cmd make
 run_cmd make check
 

--- a/src/k2hftfdcache.cc
+++ b/src/k2hftfdcache.cc
@@ -209,6 +209,8 @@ void* K2hFtFdCache::WorkerThread(void* param)
 	if(-1 == epoll_ctl(pFdCache->epollfd, EPOLL_CTL_DEL, sigfd, NULL)){
 		ERR_K2HFTPRN("Failed to remove signal fd(%d) from epoll fd(%d) by errno(%d), but continue...", sigfd, pFdCache->epollfd, errno);
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress unreadVariable
 	K2HFT_CLOSE(sigfd);
 
 	pthread_exit(NULL);
@@ -310,6 +312,8 @@ bool K2hFtFdCache::DeleteFileWatchEpoll(PK2HFTFW pfw)
 	MSG_K2HFTPRN("Succeed deleting file watch for %s", pfw->filepath.c_str());
 
 	// no care for lockval
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_DELETE(pfw);
 
 	return true;
@@ -626,6 +630,7 @@ bool K2hFtFdCache::Write(const string& filepath, int openflags, mode_t openmode,
 	fullock_rwlock_unlock(fd, 0, 1);					// UNLOCK
 
 	if(K2HFT_INVALID_HANDLE != direct_fd){
+		// cppcheck-suppress unreadVariable
 		K2HFT_CLOSE(direct_fd);
 	}
 	return result;

--- a/src/k2hftfusesvr.cc
+++ b/src/k2hftfusesvr.cc
@@ -385,16 +385,17 @@ bool Processing(K2hFtSvrInfo& confinfo, K2hFtPluginMan& pluginman, K2HShm* pTran
 
 				}else{
 					// put file, do stacking
-					size_t	NewSize = FilePutSize + ((!confinfo.IsBinMode() && 0x00 == data[datalength - 1]) ? (datalength - 1) : datalength);
+					size_t			NewSize = FilePutSize + ((!confinfo.IsBinMode() && 0x00 == data[datalength - 1]) ? (datalength - 1) : datalength);
+					unsigned char*	pTmpFile;
 
-					if(NULL == (pFileOutput = reinterpret_cast<unsigned char*>(realloc(pFileOutput, NewSize)))){
+					if(NULL == (pTmpFile = reinterpret_cast<unsigned char*>(realloc(pFileOutput, NewSize)))){
 						ERR_K2HFTPRN("Could not allocate memory, but continue...");
 					}else{
+						pFileOutput = pTmpFile;
 						memcpy(&pFileOutput[FilePutSize], data, ((!confinfo.IsBinMode() && 0x00 == data[datalength - 1]) ? (datalength - 1) : datalength));
 						FilePutSize = NewSize;
 					}
 				}
-
 				pLines = pNextLines;
 			}
 

--- a/src/k2hftinfo.cc
+++ b/src/k2hftinfo.cc
@@ -518,6 +518,9 @@ K2hFtInfo::K2hFtInfo(const char* conffile, mode_t init_mode, mode_t init_dmode, 
 		MaskBitCnt(8), CMaskBitCnt(4), MaxElementCnt(32), PageSize(128), DtorThreadCnt(1), DtorCtpPath(K2HFT_K2HTPDTOR),
 		IsBinaryMode(false), ExpireTime(0), DirMode(0), DirUid(0), DirGid(0), InitTime(common_init_time)
 {
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress noOperatorEq
+	// cppcheck-suppress noCopyConstructor
 	prule_lockval	= new int;
 	*prule_lockval	= FLCK_NOSHARED_MUTEX_VAL_UNLOCKED;
 
@@ -578,6 +581,8 @@ bool K2hFtInfo::InitializeOutputFiles(void) const
 			// found output path
 			if(S_ISDIR(pRule->Mode) && '/' == pRule->OutputPath[pRule->OutputPath.length() - 1]){
 				// output path is directory
+				// cppcheck-suppress unmatchedSuppression
+				// cppcheck-suppress stlIfStrFind
 				if('/' == pRule->OutputPath[0] && 0 != pRule->OutputPath.find(K2hFtManage::GetMountPoint())){
 					// directory is not under mount point
 
@@ -655,6 +660,8 @@ bool K2hFtInfo::InitializeOutputFiles(void) const
 
 			}else{
 				// output path is file
+				// cppcheck-suppress unmatchedSuppression
+				// cppcheck-suppress stlIfStrFind
 				if('/' == pRule->OutputPath[0] && 0 != pRule->OutputPath.find(K2hFtManage::GetMountPoint())){
 					// file is not under mount point
 					if('/' == pRule->OutputPath[pRule->OutputPath.length() - 1]){
@@ -704,6 +711,7 @@ bool K2hFtInfo::InitializeOutputFiles(void) const
 							}
 						}else{
 							// need to same directory
+							// cppcheck-suppress stlIfStrFind
 							if(pRule2->TargetPath != tmppath && 0 == tmppath.find(pRule2->TargetPath) && '/' == tmppath[pRule2->TargetPath.length()]){
 								// same directory
 								string	tmpfile = tmppath.substr(pRule2->TargetPath.length() + 1);
@@ -1029,6 +1037,9 @@ bool K2hFtInfo::LoadIni(const char* conffile, mode_t init_mode, mode_t init_dmod
 					}
 					strlst_t	values;
 					parse_ini_value(value, values);
+
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress stlSize
 					if(0 == values.size()){
 						// any pattern
 						MSG_K2HFTPRN("keyword(%s)'s value(%s) in rule section(%s) has nothing, this is any pattern hits.", key.c_str(), value.c_str(), (is_dir_rule ? INI_K2HFT_RULEDIR_SEC_STR : INI_K2HFT_RULE_SEC_STR));
@@ -1047,6 +1058,9 @@ bool K2hFtInfo::LoadIni(const char* conffile, mode_t init_mode, mode_t init_dmod
 					}else{
 						string			strcompptn	= values.front();
 						values.pop_front();
+
+						// cppcheck-suppress unmatchedSuppression
+						// cppcheck-suppress stlSize
 						string			strrepptn	= 0 < values.size() ? values.front() : "";
 						PK2HFTMATCHPTN	pMatchPtn	= build_k2hft_match_pattern(strcompptn.c_str(), strrepptn.c_str());
 						if(!pMatchPtn){
@@ -1071,14 +1085,14 @@ bool K2hFtInfo::LoadIni(const char* conffile, mode_t init_mode, mode_t init_dmod
 				if(0 < DenyMatchs.size()){
 					WAN_K2HFTPRN("rule section(%s) is Default Deny from All, but it has some DENY keywords, so skip those and continue...", (is_dir_rule ? INI_K2HFT_RULEDIR_SEC_STR : INI_K2HFT_RULE_SEC_STR));
 
-					for(k2hftmatchlist_t::iterator iter = DenyMatchs.begin(); iter != DenyMatchs.end(); ++iter){
-						K2HFT_DELETE(*iter);
+					for(k2hftmatchlist_t::iterator iter2 = DenyMatchs.begin(); iter2 != DenyMatchs.end(); ++iter2){
+						K2HFT_DELETE(*iter2);
 					}
 					DenyMatchs.clear();
 				}
 				// copy allow list
-				for(k2hftmatchlist_t::iterator iter = AllowMatchs.begin(); iter != AllowMatchs.end(); ++iter){
-					pTmpRule->MatchingList.push_back(*iter);
+				for(k2hftmatchlist_t::iterator iter3 = AllowMatchs.begin(); iter3 != AllowMatchs.end(); ++iter3){
+					pTmpRule->MatchingList.push_back(*iter3);
 				}
 				AllowMatchs.clear();
 
@@ -1087,14 +1101,14 @@ bool K2hFtInfo::LoadIni(const char* conffile, mode_t init_mode, mode_t init_dmod
 				if(0 < AllowMatchs.size()){
 					WAN_K2HFTPRN("rule section(%s) is Default Deny from All, but it has some DENY keywords, so skip those and continue...", (is_dir_rule ? INI_K2HFT_RULEDIR_SEC_STR : INI_K2HFT_RULE_SEC_STR));
 
-					for(k2hftmatchlist_t::iterator iter = AllowMatchs.begin(); iter != AllowMatchs.end(); ++iter){
-						K2HFT_DELETE(*iter);
+					for(k2hftmatchlist_t::iterator iter2 = AllowMatchs.begin(); iter2 != AllowMatchs.end(); ++iter2){
+						K2HFT_DELETE(*iter2);
 					}
 					AllowMatchs.clear();
 				}
 				// copy deny list
-				for(k2hftmatchlist_t::iterator iter = DenyMatchs.begin(); iter != DenyMatchs.end(); ++iter){
-					pTmpRule->MatchingList.push_back(*iter);
+				for(k2hftmatchlist_t::iterator iter3 = DenyMatchs.begin(); iter3 != DenyMatchs.end(); ++iter3){
+					pTmpRule->MatchingList.push_back(*iter3);
 				}
 				DenyMatchs.clear();
 			}
@@ -1702,8 +1716,6 @@ bool K2hFtInfo::LoadYamlRuleSec(yaml_parser_t& yparser, mode_t init_mode, mode_t
 
 	// Loading
 	string	key("");
-	string	strcompptn("");
-	string	strrepptn("");
 	bool	result				= true;
 	bool	need_delete_event	= false;
 	for(bool is_loop = true, in_mapping = false; is_loop && result; ){

--- a/src/k2hftinfo.h
+++ b/src/k2hftinfo.h
@@ -186,6 +186,8 @@ typedef	std::map<std::string, PK2HFTRULE>	k2hftrulemap_t;
 //---------------------------------------------------------
 class K2hFtManage;
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress noCopyConstructor
 class K2hFtInfo
 {
 	friend class K2hFtManage;

--- a/src/k2hftman.cc
+++ b/src/k2hftman.cc
@@ -127,8 +127,7 @@ void* K2hFtManage::TimeupWorkerProc(void* param)
 			uint64_t	filehandle	= iter->first;
 			PK2HFTVALUE	pValue		= iter->second;
 
-			bool	result;
-			if(false == (result = pFtMan->confinfo.Processing(&(pFtMan->k2hash), pValue, filehandle, pFtMan->fdcache, pFtMan->pluginman))){
+			if(false == pFtMan->confinfo.Processing(&(pFtMan->k2hash), pValue, filehandle, pFtMan->fdcache, pFtMan->pluginman)){
 				ERR_K2HFTPRN("Something error occurred during processing in timeup thread, skip it.");
 			}
 			K2HFT_FREE(pValue);

--- a/src/k2hftplugin.cc
+++ b/src/k2hftplugin.cc
@@ -338,6 +338,8 @@ pid_t K2hFtPluginMan::RunPluginProcess(const char* pluginparam, const char* outp
 				exit(EXIT_FAILURE);
 			}
 			// close writer fd
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress unreadVariable
 			K2HFT_CLOSE(child_wr_pipe);
 		}
 
@@ -453,7 +455,11 @@ pid_t K2hFtPluginMan::RunPluginProcess(const char* pluginparam, const char* outp
 			exit(EXIT_FAILURE);
 		}
 		// close all
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		K2HFT_CLOSE(child_input_pipe);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress unreadVariable
 		K2HFT_CLOSE(fd);
 
 		MSG_K2HFTPRN("CHILD PROCESS: Started child plugin(%s) process(pid=%d).", filename.c_str(), getpid());
@@ -482,11 +488,9 @@ pid_t K2hFtPluginMan::RunPluginProcess(const char* pluginparam, const char* outp
 //---------------------------------------------------------
 // Methods
 //---------------------------------------------------------
-K2hFtPluginMan::K2hFtPluginMan(void) : pfdcache(NULL), mountpoint(""), condname(""), mutexname(""), lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED)
+K2hFtPluginMan::K2hFtPluginMan(void) : pfdcache(NULL), mountpoint(""), condname(K2HFT_PLUGIN_CONDNAME_PREFIX), mutexname(K2HFT_PLUGIN_MUTEXNAME_PREFIX), lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED)
 {
 	// set named condition/mutex value
-	condname	= K2HFT_PLUGIN_CONDNAME_PREFIX;
-	mutexname	= K2HFT_PLUGIN_MUTEXNAME_PREFIX;
 	condname	+= to_string(getpid());
 	mutexname	+= to_string(getpid());
 }
@@ -657,6 +661,8 @@ bool K2hFtPluginMan::RunPlugin(PK2HFT_PLUGIN pplugin, bool is_wait_cond)
 		pplugin->st_dev	= 0;
 		pplugin->st_ino	= 0;
 
+												// cppcheck-suppress unmatchedSuppression
+												// cppcheck-suppress stlIfStrFind
 	}else if(!mountpoint.empty() && 0 == pplugin->OutputPath.find(mountpoint)){
 		// output directory is under mount point,
 		// so we do not need to make directory and watch it.
@@ -939,6 +945,8 @@ bool K2hFtPluginMan::Write(PK2HFT_PLUGIN pplugin, unsigned char* pdata, size_t l
 	}
 
 	// check output
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlIfStrFind
 	if(!pplugin->OutputPath.empty() && (mountpoint.empty() || 0 != pplugin->OutputPath.find(mountpoint))){
 		if(!pfdcache->Find(pplugin->OutputPath, pplugin->st_dev, pplugin->st_ino)){
 			// output file is changed or removed, so need to restart plugin.

--- a/src/k2hftstructure.h
+++ b/src/k2hftstructure.h
@@ -106,7 +106,10 @@ inline bool FreeK2hFtKey(unsigned char* pk2hftkey)
 		ERR_K2HFTPRN("pk2hftkey is NULL.");
 		return false;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_FREE(pk2hftkey);
+
 	return true;
 }
 
@@ -206,7 +209,10 @@ inline bool FreeK2hFtValue(PK2HFTVALUE pk2hftval)
 		ERR_K2HFTPRN("pk2hftval is NULL.");
 		return false;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_FREE(pk2hftval);
+
 	return true;
 }
 
@@ -287,6 +293,8 @@ inline bool FreeK2hFtLine(PK2HFTLINE pk2hftline)
 		ERR_K2HFTPRN("pk2hftline is NULL.");
 		return false;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_FREE(pk2hftline);
 	return true;
 }
@@ -298,7 +306,7 @@ inline PK2HFTLINE GetNextK2hFtLine(PK2HFTLINE pk2hftline)
 		return NULL;
 	}
 	size_t	curlength = GetK2hFtLineSize(pk2hftline);
-	if(curlength <= 0){
+	if(curlength == 0){
 		return NULL;
 	}
 	unsigned char*	pNext = GetK2hFtLinePtr(pk2hftline);

--- a/src/k2hftutil.cc
+++ b/src/k2hftutil.cc
@@ -283,6 +283,7 @@ bool make_file_by_abs_path(const char* path, mode_t mode, string& abspath, bool 
 				return false;
 			}
 		}
+		// cppcheck-suppress unreadVariable
 		K2HFT_CLOSE(fd);
 	}
 	return check_path_real_path(path, abspath);
@@ -351,7 +352,7 @@ bool cvt_mode_string(const char* strmode, mode_t& mode)
 		return false;
 	}
 	// skip '0'
-	for(; strmode && '\0' != *strmode && '0' == *strmode; ++strmode);
+	for(; strmode && '0' == *strmode; ++strmode);
 
 	mode = 0;
 	if(0 < strlen(strmode)){
@@ -526,8 +527,12 @@ char** convert_strlst_to_chararray(const strlst_t& list)
 void free_chararray(char** pparray)
 {
 	for(char** pptmp = pparray; pptmp && *pptmp; ++pptmp){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress identicalInnerCondition
 		K2HFT_FREE(*pptmp);
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_FREE(pparray);
 }
 

--- a/src/k2hftwbuf.cc
+++ b/src/k2hftwbuf.cc
@@ -57,10 +57,12 @@ bool K2hFtBinBuff::AppendStringBuff(const unsigned char* data, size_t length, bo
 		// buffer over flow, so reallocate
 		CacheBuffSize += max(K2hFtBinBuff::BUFFER_SINGLE_SIZE, (length + 1));
 
-		if(NULL == (CacheBuff = reinterpret_cast<unsigned char*>(realloc(CacheBuff, CacheBuffSize)))){
+		unsigned char*	TmpBuff;
+		if(NULL == (TmpBuff = reinterpret_cast<unsigned char*>(realloc(CacheBuff, CacheBuffSize)))){
 			ERR_K2HFTPRN("Could not allocate memory.");
 			return false;
 		}
+		CacheBuff = TmpBuff;
 	}
 	// append data
 	if(data && 0 < length){
@@ -325,6 +327,8 @@ bool K2hFtWriteBuff::StackPush(unsigned char* data, size_t length, pid_t pid)
 	if(pOutput != data){		// [NOTICE]
 		K2HFT_FREE(pOutput);
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	K2HFT_FREE(data);
 
 	return true;


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added cppcheck
We made use of cppcheck.  
cppcheck will automatically run on TravisCI.  
If you want to run it manually, please use `make cppcheck`.  

In this PR, we corrected errors etc. detected by cppcheck.

#### NOTE
cppcheck depends on the OS of the build environment, and different versions are used for each.  
This PR is trying to eliminate this difference.

