### PR TITLE
Updated files for release 1.0.36

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+k2hftfuse (1.0.36) trusty; urgency=low
+
+  * Fixed centos8 build and removed centos6 build - #32
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 17 Dec 2020 19:06:50 +0900
+
 k2hftfuse (1.0.35) trusty; urgency=low
 
   * Switched Travis CI to Github actions and extended supported OS - #30


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
#### Changes from 1.0.35 to 1.0.36
- Fixed centos8 build and removed centos6 build - #32

