### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -43,7 +43,7 @@ This section instructs how to install each dependent library and the header file
 
 **Note**: Skip reading this section if you have installed each dependent library and the header files from [GitHub](https://github.com/yahoojapan) in the previous section.
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -54,7 +54,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For users who use supported Fedora other than latest version, follow the steps below:
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel chmpx-devel fuse fuse-devel -y
+$ sudo dnf install git -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/buildja.md
+++ b/buildja.md
@@ -45,7 +45,7 @@ K2HFTFUSEとK2HFTFUSESVRは、主に[FULLOCK](https://fullock.antpick.ax/indexja
 
 注：前のセクションで各依存ライブラリと[GitHub](https://github.com/yahoojapan)  からのヘッダーファイルをインストールした場合は、このセクションを読み飛ばしてください。
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -56,13 +56,24 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+Fedoraの利用者は、以下の手順に従ってください。
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c ++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2ハッシュ-devel chmpx-devel fuse fuse-devel -y
+$ sudo dnf install git -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y
 $ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
-    |スードバッシュ
-$ sudo yumインストールautoconf automake gcc gcc-c ++ gdb make libtool pkgconfig \
+    | sudo bash
+$ sudo yum install autoconf automake gcc gcc-c ++ gdb make libtool pkgconfig \
     libyaml-devel libfullock-devel k2ハッシュ-devel chmpx-devel fuse fuse-devel -y
 $ sudo yum install git -y
 ```

--- a/feature.md
+++ b/feature.md
@@ -15,6 +15,9 @@ next_string: Details
 
 # Feature
 
+## Flexible installation
+We provide suitable K2HFTFUSE installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://k2hftfuse.antpick.ax/build.html) by yourself.
+
 ## Source and Destination Components
 Connection management between the transfer source and transfer destination is managed by CHMPX as described above.  
 CHMPX is communication middleware that provides connections between hosts using Socket and provides transparent communication between programs on the host.  

--- a/featureja.md
+++ b/featureja.md
@@ -15,6 +15,9 @@ next_string: Details
 
 # 特徴
 
+## 柔軟なインストール
+K2HFTFUSEは、あなたのOSに応じて、柔軟にインストールが可能です。あなたのOSが、Ubuntu、CentOS、Fedora、Debianなら、[packagecloud.io](https://packagecloud.io/antpickax/stable)からソースコードをビルドすることなく、簡単にインストールできます。それ以外のOSであっても、自身で[ビルド](https://k2hftfuse.antpick.ax/buildja.html)して使うことができます。
+
 ## 転送元/転送先の構成
 転送元と転送先の構成は、上述したとおりCHMPXというプログラムに任せています。  
 簡単な説明として、このCHMPXはSocketによるサーバー間の常時接続を提供し、サーバー上のプログラム同士の透過的なコミュニケーションを提供する通信ミドルウエアです。  

--- a/usage.md
+++ b/usage.md
@@ -29,7 +29,7 @@ The **K2HFTFUSE** publishes [packages](https://packagecloud.io/app/antpickax/sta
 The package of the **K2HFTFUSE** is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -41,7 +41,19 @@ To install the developer package, please install the following package.
 $ sudo apt-get install k2hftfuse-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hftfuse
+```
+To install the developer package, please install the following package.
+```
+$ sudo dnf install k2hftfuse-devel
+```
+
+#### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -29,7 +29,7 @@ next_string: Build
 **K2HFTFUSE** のパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -41,7 +41,19 @@ $ sudo apt-get install k2hftfuse
 $ sudo apt-get install k2hftfuse-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hftfuse
+```
+開発者向けパッケージをインストールする場合は、以下のパッケージをインストールしてください。
+```
+$ sudo dnf install k2hftfuse-devel
+```
+
+#### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.