### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# For CentOS8, installing libyaml-devel from PowerTools( PwoerTools -> powertools at 2020/12 )
 	#

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@
 #
 
 SUBDIRS=src docs tests buildutils
-EXTRA_DIST=RELEASE_VERSION
+EXTRA_DIST=RELEASE_VERSION @CONFIGURECUSTOM@
 
 CPPCHECK_CMD=	cppcheck
 CPPCHECK_OPT=	--quiet \
@@ -31,7 +31,10 @@ cppcheck:
 	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_PROG_RANLIB
 #
 # Checks for header files.
 #
-AC_CHECK_HEADERS([stdlib.h stdio.h string.h fcntl.h syslog.h])
+AC_CHECK_HEADERS([stdlib.h stdio.h string.h fcntl.h syslog.h strings.h unistd.h])
 
 #
 # Checks for typedefs, structures, and compiler characteristics.
@@ -80,15 +80,40 @@ AC_STRUCT_ST_BLOCKS
 AC_CONFIG_MACRO_DIR([m4])
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="k2hftfuse"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="K2HASH_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2hftfuse")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r k2hftfuse -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HASH_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o "${custom_git_org}" -r "${custom_git_repo}" -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hftfuse.1 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hftfuse.1 -long`")
@@ -176,7 +201,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/src/k2hftfusesvr.cc
+++ b/src/k2hftfusesvr.cc
@@ -116,7 +116,7 @@ static void k2hftfusesvr_print_usage(FILE* stream)
 					"\n"	);
 }
 
-static bool parse_parameter(int argc, char** argv, optparams_t& optparams)
+static bool parse_parameter(int argc, const char** argv, optparams_t& optparams)
 {
 	if(argc < 2 || !argv){
 		ERR_K2HFTPRN("no parameters.");
@@ -131,7 +131,7 @@ static bool parse_parameter(int argc, char** argv, optparams_t& optparams)
 		param.num_value = 0;
 
 		// get option name
-		char*	popt = argv[cnt];
+		const char*	popt = argv[cnt];
 		if(K2HFT_ISEMPTYSTR(popt)){
 			continue;		// skip
 		}
@@ -142,14 +142,14 @@ static bool parse_parameter(int argc, char** argv, optparams_t& optparams)
 
 		// check option parameter
 		if((cnt + 1) < argc && argv[cnt + 1]){
-			char*	pparam = argv[cnt + 1];
+			const char*	pparam = argv[cnt + 1];
 			if(!K2HFT_ISEMPTYSTR(pparam) && '-' != *pparam){
 				// found param
 				param.rawstring = pparam;
 
 				// check number
 				param.is_number = true;
-				for(char* ptmp = pparam; *ptmp; ++ptmp){
+				for(const char* ptmp = pparam; *ptmp; ++ptmp){
 					if(0 == isdigit(*ptmp)){
 						param.is_number = false;
 						break;
@@ -436,7 +436,7 @@ bool Processing(K2hFtSvrInfo& confinfo, K2hFtPluginMan& pluginman, K2HShm* pTran
 //---------------------------------------------------------
 // Main
 //---------------------------------------------------------
-int main(int argc, char** argv)
+int main(int argc, const char** argv)
 {
 	// always foreground mode
 	k2hft_foreground_mode = true;

--- a/src/k2hftman.cc
+++ b/src/k2hftman.cc
@@ -100,6 +100,8 @@ void* K2hFtManage::TimeupWorkerProc(void* param)
 		for(size_t cnt = 0; cnt < sleepcnt && pFtMan->run_thread; ++cnt){
 			nanosleep(&sleeptime, NULL);
 		}
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress knownConditionTrueFalse
 		if(!pFtMan->run_thread){
 			break;
 		}
@@ -241,7 +243,7 @@ bool K2hFtManage::Clean(void)
 	return result;
 }
 
-bool K2hFtManage::Initialize(mode_t* pset_umask, uid_t* pset_uid, gid_t* pset_gid)
+bool K2hFtManage::Initialize(const mode_t* pset_umask, const uid_t* pset_uid, const gid_t* pset_gid)
 {
 	// Lock
 	while(!fullock::flck_trylock_noshared_mutex(&conf_lockval));

--- a/src/k2hftman.h
+++ b/src/k2hftman.h
@@ -70,7 +70,7 @@ class K2hFtManage
 		virtual ~K2hFtManage(void);
 
 		bool Clean(void);
-		bool Initialize(mode_t* pset_umask, uid_t* pset_uid, gid_t* pset_gid);
+		bool Initialize(const mode_t* pset_umask, const uid_t* pset_uid, const gid_t* pset_gid);
 		bool Initialize(const char* config, bool is_run_chmpx = false, const char* chmpxlog = NULL);
 
 		bool IsBinMode(void) const { return confinfo.IsBinMode(); }


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed an error output by cppcheck 2.7(etc)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.


