### PR TITLE
Fixed .gitignore to exclude APKBUILD.templ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ stamp-h1
 #
 Makefile.in
 Makefile
-
+buildutils/APKBUILD.templ
 
 #
 # archive files and backups


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Fixed leaking `buildutils/APKBUILD.templ` in `.gitignore`.