### PR TITLE
Changed supported OS and modified some codes

### DIFF
--- a/.github/workflows/build_helper.sh
+++ b/.github/workflows/build_helper.sh
@@ -393,7 +393,7 @@ run_pre_create_package()
 run_create_package()
 {
 	if ! CONFIGUREOPT="${CONFIGURE_EXT_OPT}" /bin/sh -c "${CREATE_PACKAGE_TOOL} --buildnum ${CI_BUILD_NUMBER} ${CREATE_PACKAGE_TOOL_OPT} ${CREATE_PACKAGE_TOOL_OPT_AUTO}"; then
-		PRNERR "Failed to create debian type packages"
+		PRNERR "Failed to create ${CI_OSTYPE} packages"
 		return 1
 	fi
 	return 0
@@ -670,12 +670,42 @@ if [ -n "${OPT_DEVELOPER_FULLNAME}" ]; then
 	CI_DEVELOPER_FULLNAME="${OPT_DEVELOPER_FULLNAME}"
 elif [ -n "${ENV_DEVELOPER_FULLNAME}" ]; then
 	CI_DEVELOPER_FULLNAME="${ENV_DEVELOPER_FULLNAME}"
+else
+	# [NOTE]
+	# If this variable is not set in a project that uses configure,
+	# an attempt will be made to load the value from configure.ac etc.
+	#
+	if [ -f "${SRCTOP}/configure.custom" ]; then
+		CI_DEVELOPER_FULLNAME=$(grep '^[[:space:]]*DEB_NAME[[:space:]]*=' "${SRCTOP}/configure.custom" | sed -e 's|^[[:space:]]*DEB_NAME[[:space:]]*=[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g')
+	fi
+	if [ -z "${CI_DEVELOPER_FULLNAME}" ] && [ -f "${SRCTOP}/configure.ac" ]; then
+		CI_DEVELOPER_FULLNAME=$(grep '^[[:space:]]*custom_dev_name[[:space:]]*=' "${SRCTOP}/configure.ac" | grep -v 'DEB_NAME' | sed -e 's|^[[:space:]]*custom_dev_name[[:space:]]*=[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g' -e 's|"||g')
+	fi
+	if [ -z "${CI_DEVELOPER_FULLNAME}" ]; then
+		PRNWARN "DEVELOPER_FULLNAME is not set in the options or environment variables. There is no choice but to set the default value."
+		CI_DEVELOPER_FULLNAME="ANTPICKAX_DEVELOPER"
+	fi
 fi
 
 if [ -n "${OPT_DEVELOPER_EMAIL}" ]; then
 	CI_DEVELOPER_EMAIL="${OPT_DEVELOPER_EMAIL}"
 elif [ -n "${ENV_DEVELOPER_EMAIL}" ]; then
 	CI_DEVELOPER_EMAIL="${ENV_DEVELOPER_EMAIL}"
+else
+	# [NOTE]
+	# If this variable is not set in a project that uses configure,
+	# an attempt will be made to load the value from configure.ac etc.
+	#
+	if [ -f "${SRCTOP}/configure.custom" ]; then
+		CI_DEVELOPER_EMAIL=$(grep '^[[:space:]]*DEV_EMAIL[[:space:]]*=' "${SRCTOP}/configure.custom" | sed -e 's|^[[:space:]]*DEV_EMAIL[[:space:]]*=[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g')
+	fi
+	if [ -z "${CI_DEVELOPER_EMAIL}" ] && [ -f "${SRCTOP}/configure.ac" ]; then
+		CI_DEVELOPER_EMAIL=$(grep '^[[:space:]]*custom_dev_email[[:space:]]*=' "${SRCTOP}/configure.ac" | grep -v 'DEV_EMAIL' | sed -e 's|^[[:space:]]*custom_dev_email[[:space:]]*=[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g' -e 's|"||g')
+	fi
+	if [ -z "${CI_DEVELOPER_EMAIL}" ]; then
+		PRNWARN "DEVELOPER_EMAIL is not set in the options or environment variables. There is no choice but to set the default value."
+		CI_DEVELOPER_EMAIL="antpickax-support@mail.yahoo.co.jp"
+	fi
 fi
 
 if [ -n "${OPT_FORCE_PUBLISH}" ]; then
@@ -743,13 +773,19 @@ elif [ -n "${ENV_PACKAGECLOUD_DOWNLOAD_REPO}" ]; then
 fi
 
 #
-# Set environments for debian package
+# Set environments for debian/alpine package
 #
 if [ -n "${CI_DEVELOPER_FULLNAME}" ]; then
-	export DEBEMAIL="${CI_DEVELOPER_FULLNAME}"
+	export DEBFULLNAME="${CI_DEVELOPER_FULLNAME}"
+else
+	PRNERR "\"CI_DEVELOPER_FULLNAME\" value is not set."
+	exit 1
 fi
 if [ -n "${CI_DEVELOPER_EMAIL}" ]; then
-	export DEBFULLNAME="${CI_DEVELOPER_EMAIL}"
+	export DEBEMAIL="${CI_DEVELOPER_EMAIL}"
+else
+	PRNERR "\"CI_DEVELOPER_EMAIL\" value is not set."
+	exit 1
 fi
 
 # [NOTE] for ubuntu/debian
@@ -839,14 +875,6 @@ elif [ "${IS_OS_DEBIAN}" -eq 1 ]; then
 	MAKE_TEST_OPT="${MAKE_TEST_OPT_DEBIAN}"
 	CREATE_PACKAGE_TOOL="${CREATE_PACKAGE_TOOL_DEBIAN}"
 	CREATE_PACKAGE_TOOL_OPT="${CREATE_PACKAGE_TOOL_OPT_DEBIAN}"
-
-elif [ "${IS_OS_CENTOS}" -eq 1 ]; then
-	AUTOGEN_EXT_OPT="${AUTOGEN_EXT_OPT_RPM}"
-	CONFIGURE_EXT_OPT="${CONFIGURE_EXT_OPT_RPM}"
-	BUILD_MAKE_EXT_OPT="${BUILD_MAKE_EXT_OPT_DEBIAN}"
-	MAKE_TEST_OPT="${MAKE_TEST_OPT_DEBIAN}"
-	CREATE_PACKAGE_TOOL="${CREATE_PACKAGE_TOOL_RPM}"
-	CREATE_PACKAGE_TOOL_OPT="${CREATE_PACKAGE_TOOL_OPT_RPM}"
 
 elif [ "${IS_OS_FEDORA}" -eq 1 ]; then
 	AUTOGEN_EXT_OPT="${AUTOGEN_EXT_OPT_RPM}"
@@ -968,7 +996,6 @@ echo ""
 echo "  DIST_TAG                      = ${DIST_TAG}"
 echo "  IS_OS_UBUNTU                  = ${IS_OS_UBUNTU}"
 echo "  IS_OS_DEBIAN                  = ${IS_OS_DEBIAN}"
-echo "  IS_OS_CENTOS                  = ${IS_OS_CENTOS}"
 echo "  IS_OS_FEDORA                  = ${IS_OS_FEDORA}"
 echo "  IS_OS_ROCKY                   = ${IS_OS_ROCKY}"
 echo "  IS_OS_ALPINE                  = ${IS_OS_ALPINE}"
@@ -1036,7 +1063,7 @@ if [ "${CI_USE_PACKAGECLOUD_REPO}" -eq 1 ]; then
 	#
 	# Setup packagecloud.io repository
 	#
-	if [ "${IS_OS_CENTOS}" -eq 1 ] || [ "${IS_OS_FEDORA}" -eq 1 ] || [ "${IS_OS_ROCKY}" -eq 1 ]; then
+	if [ "${IS_OS_FEDORA}" -eq 1 ] || [ "${IS_OS_ROCKY}" -eq 1 ]; then
 		PC_REPO_ADD_SH="script.rpm.sh"
 		PC_REPO_ADD_SH_RUN="bash"
 	elif [ "${IS_OS_UBUNTU}" -eq 1 ] || [ "${IS_OS_DEBIAN}" -eq 1 ]; then
@@ -1056,7 +1083,7 @@ if [ "${CI_USE_PACKAGECLOUD_REPO}" -eq 1 ]; then
 			exit 1
 		fi
 	else
-		PRNWARN "OS is not debian/ubuntu nor centos/fedora/rocky nor alpine, then we do not know which download script use. Thus skip to setup packagecloud.io repository."
+		PRNWARN "OS is not debian/ubuntu nor fedora/rocky nor alpine, then we do not know which download script use. Thus skip to setup packagecloud.io repository."
 	fi
 else
 	PRNINFO "Not set packagecloud.io repository."
@@ -1090,28 +1117,7 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 	GEM_BIN="gem"
 	GEM_INSTALL_CMD="install"
 
-	if [ "${IS_OS_CENTOS}" -eq 1 ] && echo "${CI_OSTYPE}" | sed -e 's#:##g' | grep -q -i -e 'centos7' -e 'centos6'; then
-		#
-		# Case for CentOS
-		#
-		PRNWARN "OS is CentOS 7(6), so install ruby by special means(SCL)."
-
-		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" centos-release-scl || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install SCL packages"
-			exit 1
-		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" rh-ruby27 rh-ruby27-ruby-devel rh-ruby27-rubygem-rake || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install ruby packages"
-			exit 1
-		fi
-		. /opt/rh/rh-ruby27/enable
-
-		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install packagecloud.io upload tools"
-			exit 1
-		fi
-
-	elif [ "${IS_OS_ALPINE}" -eq 1 ]; then
+	if [ "${IS_OS_ALPINE}" -eq 1 ]; then
 		#
 		# Case for Alpine
 		#
@@ -1241,7 +1247,7 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 
 	else
 		#
-		# Case for other than CentOS / Alpine / Debian 10 / Rocky Linux 8
+		# Case for other than Alpine / Debian 10 / Rocky Linux 8
 		#
 		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" rake package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install packagecloud.io upload tools"
@@ -1258,29 +1264,10 @@ PRNSUCCESS "Install published tools for uploading packages to packagecloud.io"
 #--------------------------------------------------------------
 PRNTITLE "Install cppcheck"
 
-IS_SET_ANOTHER_REPOSITORIES=0
 if [ "${RUN_CPPCHECK}" -eq 1 ]; then
 	PRNINFO "Install cppcheck package."
 
-	if [ "${IS_OS_CENTOS}" -eq 1 ]; then
-		#
-		# CentOS
-		#
-		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" epel-release || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install epel repository"
-			exit 1
-		fi
-		if ({ RUNCMD yum-config-manager --disable epel || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to disable epel repository"
-			exit 1
-		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" --enablerepo=epel "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" cppcheck || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install cppcheck from epel repository"
-			exit 1
-		fi
-		IS_SET_ANOTHER_REPOSITORIES=1
-
-	elif [ "${IS_OS_FEDORA}" -eq 1 ]; then
+	if [ "${IS_OS_FEDORA}" -eq 1 ]; then
 		#
 		# Fedora
 		#
@@ -1323,7 +1310,6 @@ if [ "${RUN_CPPCHECK}" -eq 1 ]; then
 			PRNERR "Failed to install cppcheck"
 			exit 1
 		fi
-		IS_SET_ANOTHER_REPOSITORIES=1
 
 	elif [ "${IS_OS_UBUNTU}" -eq 1 ] || [ "${IS_OS_DEBIAN}" -eq 1 ]; then
 		#
@@ -1359,27 +1345,7 @@ PRNTITLE "Install shellcheck"
 if [ "${RUN_SHELLCHECK}" -eq 1 ]; then
 	PRNINFO "Install shellcheck package."
 
-	if [ "${IS_OS_CENTOS}" -eq 1 ]; then
-		#
-		# CentOS
-		#
-		if [ "${IS_SET_ANOTHER_REPOSITORIES}" -eq 0 ]; then
-			if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" epel-release || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-				PRNERR "Failed to install epel repository"
-				exit 1
-			fi
-			if ({ RUNCMD yum-config-manager --disable epel || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-				PRNERR "Failed to disable epel repository"
-				exit 1
-			fi
-			IS_SET_ANOTHER_REPOSITORIES=1
-		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" --enablerepo=epel "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" ShellCheck || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install ShellCheck from epel repository"
-			exit 1
-		fi
-
-	elif [ "${IS_OS_FEDORA}" -eq 1 ]; then
+	if [ "${IS_OS_FEDORA}" -eq 1 ]; then
 		#
 		# Fedora
 		#

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,16 +61,16 @@ jobs:
       #
       matrix:
         container:
+          - ubuntu:24.04
           - ubuntu:22.04
           - ubuntu:20.04
           - debian:bookworm
           - debian:bullseye
-          - debian:buster
           - rockylinux:9
           - rockylinux:8
-          - centos:centos7
-          - fedora:39
-          - fedora:38
+          - fedora:41
+          - fedora:40
+          - alpine:3.20
           - alpine:3.19
           - alpine:3.18
 
@@ -80,18 +80,8 @@ jobs:
       options: "--privileged --cap-add SYS_ADMIN --device /dev/fuse"
 
     steps:
-      # [NOTE]
-      # actions/checkout@v3 uses nodejs v16 and will be deprecated.
-      # However, @v4 does not work on centos7 depending on the glibc version,
-      # so we will continue to use @v3.
-      #
-      - name: Checkout source code(other than centos7)
-        if: matrix.container != 'centos:centos7'
+      - name: Checkout source code
         uses: actions/checkout@v4
-
-      - name: Checkout source code(only centos7)
-        if: matrix.container == 'centos:centos7'
-        uses: actions/checkout@v3
 
       #
       # Set environments from secrets

--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -52,7 +52,6 @@
 #   PKG_EXT           : The extension of the package file
 #   IS_OS_UBUNTU      : Set to 1 for Ubuntu, 0 otherwise
 #   IS_OS_DEBIAN      : Set to 1 for Debian, 0 otherwise
-#   IS_OS_CENTOS      : Set to 1 for CentOS, 0 otherwise
 #   IS_OS_FEDORA      : Set to 1 for Fedora, 0 otherwise
 #   IS_OS_ROCKY       : Set to 1 for Rocky, 0 otherwise
 #   IS_OS_ALPINE      : Set to 1 for Alpine, 0 otherwise
@@ -81,7 +80,6 @@ PKG_EXT=""
 
 IS_OS_UBUNTU=0
 IS_OS_DEBIAN=0
-IS_OS_CENTOS=0
 IS_OS_FEDORA=0
 IS_OS_ROCKY=0
 IS_OS_ALPINE=0
@@ -94,7 +92,22 @@ if [ -z "${CI_OSTYPE}" ]; then
 	# Unknown OS : Nothing to do
 	#
 	:
-elif [ "${CI_OSTYPE}" = "ubuntu:22.04" ] || [ "${CI_OSTYPE}" = "ubuntu:jammy" ]; then
+
+elif echo "${CI_OSTYPE}" | grep -q -i -e "ubuntu:24.04" -e "ubuntu:noble"; then
+	DIST_TAG="ubuntu/noble"
+	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
+	INSTALLER_BIN="apt-get"
+	UPDATE_CMD="update"
+	UPDATE_CMD_ARG=""
+	INSTALL_CMD="install"
+	INSTALL_CMD_ARG=""
+	INSTALL_AUTO_ARG="-y"
+	INSTALL_QUIET_ARG="-qq"
+	PKG_OUTPUT_DIR="debian_build"
+	PKG_EXT="deb"
+	IS_OS_UBUNTU=1
+
+elif echo "${CI_OSTYPE}" | grep -q -i -e "ubuntu:22.04" -e "ubuntu:jammy"; then
 	DIST_TAG="ubuntu/jammy"
 	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apt-get"
@@ -108,7 +121,7 @@ elif [ "${CI_OSTYPE}" = "ubuntu:22.04" ] || [ "${CI_OSTYPE}" = "ubuntu:jammy" ];
 	PKG_EXT="deb"
 	IS_OS_UBUNTU=1
 
-elif [ "${CI_OSTYPE}" = "ubuntu:20.04" ] || [ "${CI_OSTYPE}" = "ubuntu:focal" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i -e "ubuntu:20.04" -e "ubuntu:focal"; then
 	DIST_TAG="ubuntu/focal"
 	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apt-get"
@@ -122,7 +135,7 @@ elif [ "${CI_OSTYPE}" = "ubuntu:20.04" ] || [ "${CI_OSTYPE}" = "ubuntu:focal" ];
 	PKG_EXT="deb"
 	IS_OS_UBUNTU=1
 
-elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i -e "debian:12" -e "debian:bookworm"; then
 	DIST_TAG="debian/bookworm"
 	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apt-get"
@@ -136,7 +149,7 @@ elif [ "${CI_OSTYPE}" = "debian:12" ] || [ "${CI_OSTYPE}" = "debian:bookworm" ];
 	PKG_EXT="deb"
 	IS_OS_DEBIAN=1
 
-elif [ "${CI_OSTYPE}" = "debian:11" ] || [ "${CI_OSTYPE}" = "debian:bullseye" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i -e "debian:11" -e "debian:bullseye"; then
 	DIST_TAG="debian/bullseye"
 	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apt-get"
@@ -150,21 +163,7 @@ elif [ "${CI_OSTYPE}" = "debian:11" ] || [ "${CI_OSTYPE}" = "debian:bullseye" ];
 	PKG_EXT="deb"
 	IS_OS_DEBIAN=1
 
-elif [ "${CI_OSTYPE}" = "debian:10" ] || [ "${CI_OSTYPE}" = "debian:buster" ]; then
-	DIST_TAG="debian/buster"
-	INSTALL_PKG_LIST="git autoconf autotools-dev gcc g++ make gdb dh-make fakeroot dpkg-dev devscripts libtool pkg-config ruby-dev rubygems rubygems-integration procps libyaml-dev fuse libfuse-dev k2htpdtor chmpx-dev"
-	INSTALLER_BIN="apt-get"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-qq"
-	PKG_OUTPUT_DIR="debian_build"
-	PKG_EXT="deb"
-	IS_OS_DEBIAN=1
-
-elif [ "${CI_OSTYPE}" = "rockylinux:9.0" ] || [ "${CI_OSTYPE}" = "rockylinux:9" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i "rockylinux:9"; then
 	DIST_TAG="el/9"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel fuse fuse-devel k2htpdtor chmpx-devel"
 	INSTALLER_BIN="dnf"
@@ -189,7 +188,7 @@ elif [ "${CI_OSTYPE}" = "rockylinux:9.0" ] || [ "${CI_OSTYPE}" = "rockylinux:9" 
 		echo "[ERROR] Failed to install \"dnf-command(config-manager)\". The script doesn't break here, but fails to install the package."
 	fi
 
-elif [ "${CI_OSTYPE}" = "rockylinux:8.6" ] || [ "${CI_OSTYPE}" = "rockylinux:8" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i "rockylinux:8"; then
 	DIST_TAG="el/8"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel fuse fuse-devel k2htpdtor chmpx-devel"
 	INSTALLER_BIN="dnf"
@@ -214,22 +213,8 @@ elif [ "${CI_OSTYPE}" = "rockylinux:8.6" ] || [ "${CI_OSTYPE}" = "rockylinux:8" 
 		echo "[ERROR] Failed to install \"dnf-command(config-manager)\". The script doesn't break here, but fails to install the package."
 	fi
 
-elif [ "${CI_OSTYPE}" = "centos:7" ] || [ "${CI_OSTYPE}" = "centos:centos7" ]; then
-	DIST_TAG="el/7"
-	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel fuse fuse-devel k2htpdtor chmpx-devel"
-	INSTALLER_BIN="yum"
-	UPDATE_CMD="update"
-	UPDATE_CMD_ARG=""
-	INSTALL_CMD="install"
-	INSTALL_CMD_ARG=""
-	INSTALL_AUTO_ARG="-y"
-	INSTALL_QUIET_ARG="-q"
-	PKG_OUTPUT_DIR="."
-	PKG_EXT="rpm"
-	IS_OS_CENTOS=1
-
-elif [ "${CI_OSTYPE}" = "fedora:39" ]; then
-	DIST_TAG="fedora/39"
+elif echo "${CI_OSTYPE}" | grep -q -i "fedora:41"; then
+	DIST_TAG="fedora/41"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel fuse fuse-devel k2htpdtor chmpx-devel"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"
@@ -242,8 +227,8 @@ elif [ "${CI_OSTYPE}" = "fedora:39" ]; then
 	PKG_EXT="rpm"
 	IS_OS_FEDORA=1
 
-elif [ "${CI_OSTYPE}" = "fedora:38" ]; then
-	DIST_TAG="fedora/38"
+elif echo "${CI_OSTYPE}" | grep -q -i "fedora:40"; then
+	DIST_TAG="fedora/40"
 	INSTALL_PKG_LIST="git autoconf automake gcc gcc-c++ gdb make libtool pkgconfig redhat-rpm-config rpm-build ruby-devel rubygems procps libyaml-devel fuse fuse-devel k2htpdtor chmpx-devel"
 	INSTALLER_BIN="dnf"
 	UPDATE_CMD="update"
@@ -256,7 +241,21 @@ elif [ "${CI_OSTYPE}" = "fedora:38" ]; then
 	PKG_EXT="rpm"
 	IS_OS_FEDORA=1
 
-elif [ "${CI_OSTYPE}" = "alpine:3.19" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i "alpine:3.20"; then
+	DIST_TAG="alpine/v3.20"
+	INSTALL_PKG_LIST="bash sudo alpine-sdk automake autoconf libtool groff util-linux-misc musl-locales ruby-dev procps yaml-dev fuse-dev k2htpdtor chmpx-dev"
+	INSTALLER_BIN="apk"
+	UPDATE_CMD="update"
+	UPDATE_CMD_ARG="--no-progress"
+	INSTALL_CMD="add"
+	INSTALL_CMD_ARG="--no-progress --no-cache"
+	INSTALL_AUTO_ARG=""
+	INSTALL_QUIET_ARG="-q"
+	PKG_OUTPUT_DIR="apk_build"
+	PKG_EXT="apk"
+	IS_OS_ALPINE=1
+
+elif echo "${CI_OSTYPE}" | grep -q -i "alpine:3.19"; then
 	DIST_TAG="alpine/v3.19"
 	INSTALL_PKG_LIST="bash sudo alpine-sdk automake autoconf libtool groff util-linux-misc musl-locales ruby-dev procps yaml-dev fuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apk"
@@ -270,7 +269,7 @@ elif [ "${CI_OSTYPE}" = "alpine:3.19" ]; then
 	PKG_EXT="apk"
 	IS_OS_ALPINE=1
 
-elif [ "${CI_OSTYPE}" = "alpine:3.18" ]; then
+elif echo "${CI_OSTYPE}" | grep -q -i "alpine:3.18"; then
 	DIST_TAG="alpine/v3.18"
 	INSTALL_PKG_LIST="bash sudo alpine-sdk automake autoconf libtool groff util-linux-misc musl-locales ruby-dev procps yaml-dev fuse-dev k2htpdtor chmpx-dev"
 	INSTALLER_BIN="apk"

--- a/buildutils/APKBUILD.templ.in
+++ b/buildutils/APKBUILD.templ.in
@@ -56,7 +56,9 @@ arch="x86_64"
 license="MIT"
 
 depends="
+	procps
 	k2htpdtor
+	chmpx
 "
 depends_dev="
 	chmpx-dev
@@ -69,7 +71,6 @@ makedepends="
 	groff
 	util-linux-misc
 	musl-locales
-	procps
 	yaml-dev
 	fuse-dev
 	k2htpdtor

--- a/buildutils/alpine_build.sh
+++ b/buildutils/alpine_build.sh
@@ -62,6 +62,7 @@ APK_TOPDIR="${SRCTOP}/apk_build"
 APKBUILD_TEMPLATE_FILE="${SRCTOP}/buildutils/APKBUILD.templ"
 APKBUILD_FILE="${APK_TOPDIR}/APKBUILD"
 APKBUILD_CONFIG_DIR="${HOME}/.abuild"
+APK_KEYS_DIR="/etc/apk/keys"
 MAKE_VARIABLES_TOOL="${SRCTOP}/buildutils/make_variables.sh"
 
 PRGNAME_NOEXT=$(echo "${PRGNAME}" | sed -e 's/[\.].*$//g' | tr -d '\n')
@@ -227,15 +228,23 @@ fi
 #
 # Check running as root user
 #
+RUN_USER_ID=$(id -u)
+
+if [ -n "${RUN_USER_ID}" ] && [ "${RUN_USER_ID}" -eq 0 ]; then
+	SUDO_CMD=""
+else
+	SUDO_CMD="sudo"
+fi
+
 # [NOTE]
 # The abuild tool drains errors when run as root.
 # To avoid this, the "-F" option is required.
+# If you need verbose message, you can add "-v" option here.
 #
-RUN_USER_ID=$(id -u)
-ABUILD_OPT=""
-
 if [ -n "${RUN_USER_ID}" ] && [ "${RUN_USER_ID}" -eq 0 ]; then
 	ABUILD_OPT="-F"
+else
+	ABUILD_OPT=""
 fi
 
 #---------------------------------------------------------------
@@ -288,6 +297,28 @@ cd "${SRCTOP}" || exit 1
 echo "[TITLE] Create RSA key for signing"
 
 #
+# Determining the RSA key location directory
+#
+# [NOTE]
+# This directory path depends on the apk-tools version.
+# It is different for 2.14.4 and later and previous versions.
+#
+APKTOOLS_ALL_VER=$(apk list apk-tools | awk '{print $1}' | tail -1)
+APKTOOLS_MAJOR_VER=$(echo "${APKTOOLS_ALL_VER}" | sed -e 's#^[[:space:]]*apk-tools-##g' -e 's#-# #g' -e 's#\.# #g' | awk '{print $1}')
+APKTOOLS_MINOR_VER=$(echo "${APKTOOLS_ALL_VER}" | sed -e 's#^[[:space:]]*apk-tools-##g' -e 's#-# #g' -e 's#\.# #g' | awk '{print $2}')
+APKTOOLS_PATCH_VER=$(echo "${APKTOOLS_ALL_VER}" | sed -e 's#^[[:space:]]*apk-tools-##g' -e 's#-# #g' -e 's#\.# #g' | awk '{print $3}')
+if [ -z "${APKTOOLS_MAJOR_VER}" ] || [ -z "${APKTOOLS_MINOR_VER}" ] || [ -z "${APKTOOLS_PATCH_VER}" ]; then
+	echo "[ERROR] Could not get aok-tools package version." 1>&2
+	exit 1
+fi
+APKTOOLS_MIX_VER=$((APKTOOLS_MAJOR_VER * 1000 * 1000 + APKTOOLS_MINOR_VER * 1000 + APKTOOLS_PATCH_VER))
+if [ "${APKTOOLS_MIX_VER}" -lt 2014004 ]; then
+	RSA_KEYS_DIR="${APK_TOPDIR}"
+else
+	RSA_KEYS_DIR="${APK_KEYS_DIR}"
+fi
+
+#
 # Check "${HOME}/.abuild" directory
 #
 if [ -d "${APKBUILD_CONFIG_DIR}" ] || [ -f "${APKBUILD_CONFIG_DIR}" ]; then
@@ -318,12 +349,13 @@ if ! find "${APKBUILD_CONFIG_DIR}" -name "${DEBEMAIL}"-\*\.rsa\.pub | grep -q "$
 	echo "[ERROR] Not found ${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-<unixtime(hex)>.rsa.pub files." 1>&2
 	exit 1
 fi
-if ! cp -p "${APKBUILD_CONFIG_DIR}"/"${DEBEMAIL}"-*.rsa "${APK_TOPDIR}"; then
-	echo "[ERROR] Failed to copy RSA private key(${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-<unixtime(hex)>.rsa) to ${APK_TOPDIR} directory." 1>&2
+if ! /bin/sh -c "${SUDO_CMD} cp -p ${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-*.rsa ${RSA_KEYS_DIR} >/dev/null 2>&1"; then
+	echo "[ERROR] Failed to copy RSA private key(${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-<unixtime(hex)>.rsa) to ${RSA_KEYS_DIR} directory." 1>&2
 	exit 1
 fi
-if ! cp -p "${APKBUILD_CONFIG_DIR}"/"${DEBEMAIL}"-*.rsa.pub "${APK_TOPDIR}"; then
-	echo "[ERROR] Failed to copy RSA public key(${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-<unixtime(hex)>.rsa.pub) to ${APK_TOPDIR} directory." 1>&2
+if ! /bin/sh -c "${SUDO_CMD} cp -p ${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-*.rsa.pub ${RSA_KEYS_DIR} >/dev/null 2>&1"; then
+	echo "[ERROR] Failed to copy RSA public key(${APKBUILD_CONFIG_DIR}/${DEBEMAIL}-<unixtime(hex)>.rsa.pub) to ${RSA_KEYS_DIR} directory." 1>&2
+	exit 1
 fi
 
 #
@@ -338,12 +370,12 @@ rm -rf "${APKBUILD_CONFIG_DIR}"
 #
 # Set file name/key contents to variables
 #
-APK_PACKAGE_PRIV_KEYNAME="$(find "${APK_TOPDIR}" -name "${DEBEMAIL}"-\*\.rsa 2>/dev/null | head -1 | sed -e "s#${APK_TOPDIR}/##g" | tr -d '\n')"
-APK_PACKAGE_PUB_KEYNAME="$(find "${APK_TOPDIR}" -name "${DEBEMAIL}"-\*\.rsa\.pub 2>/dev/null | head -1 | sed -e "s#${APK_TOPDIR}/##g" | tr -d '\n')"
+APK_PACKAGE_PRIV_KEYNAME="$(find "${RSA_KEYS_DIR}" -name "${DEBEMAIL}"-\*\.rsa 2>/dev/null | head -1 | sed -e "s#${RSA_KEYS_DIR}/##g" | tr -d '\n')"
+APK_PACKAGE_PUB_KEYNAME="$(find "${RSA_KEYS_DIR}" -name "${DEBEMAIL}"-\*\.rsa\.pub 2>/dev/null | head -1 | sed -e "s#${RSA_KEYS_DIR}/##g" | tr -d '\n')"
 
 echo "[SUCCEED] Created RSA keys"
-echo "    RSA private key : ${APK_TOPDIR}/${APK_PACKAGE_PRIV_KEYNAME}"
-echo "    RSA public key  : ${APK_TOPDIR}/${APK_PACKAGE_PUB_KEYNAME}"
+echo "    RSA private key : ${RSA_KEYS_DIR}/${APK_PACKAGE_PRIV_KEYNAME}"
+echo "    RSA public key  : ${RSA_KEYS_DIR}/${APK_PACKAGE_PUB_KEYNAME}"
 echo ""
 
 #---------------------------------------------------------------
@@ -461,7 +493,7 @@ echo "[TITLE] Build APK packages."
 #
 # build APK packages
 #
-if ({ /bin/sh -c "PACKAGER_PRIVKEY=${APK_TOPDIR}/${APK_PACKAGE_PRIV_KEYNAME} abuild ${ABUILD_OPT} -r -P $(pwd)" || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's#^#    #') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+if ({ /bin/sh -c "PACKAGER_PRIVKEY=${RSA_KEYS_DIR}/${APK_PACKAGE_PRIV_KEYNAME} abuild ${ABUILD_OPT} -r -P $(pwd)" || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's#^#    #') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 	echo "[ERROR] Failed to create APK packages." 1>&2
 	exit 1
 fi

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: utils
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.93), chmpx-dev (>= 1.0.105), libfullock-dev (>= 1.0.59), k2htpdtor (>= 1.0.45), libyaml-dev, fuse, libfuse-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= @LIB_MINVER_LIBK2HASH@), chmpx-dev (>= @LIB_MINVER_LIBCHMPX@), libfullock-dev (>= @LIB_MINVER_LIBFULLOCK@), k2htpdtor (>= @LIB_MINVER_LIBK2HTPDTOR@), libyaml-dev, fuse, libfuse-dev
 Depends: ${misc:Depends}
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
@@ -20,6 +20,6 @@ Description: @SHORTDESC@ (development)
 Package: @PACKAGE_NAME@
 Section: net
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.93), chmpx (>= 1.0.105), libfullock (>= 1.0.59), k2htpdtor (>= 1.0.45), fuse
+Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= @LIB_MINVER_LIBK2HASH@), chmpx (>= @LIB_MINVER_LIBCHMPX@), libfullock (>= @LIB_MINVER_LIBFULLOCK@), k2htpdtor (>= @LIB_MINVER_LIBK2HTPDTOR@), fuse
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2hftfuse.spec.in
+++ b/buildutils/k2hftfuse.spec.in
@@ -52,8 +52,8 @@ License: @PKGLICENSE@
 @RPMPKG_GROUP@
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
-Requires: libfullock%{?_isa} >= 1.0.59, k2hash%{?_isa} >= 1.0.93, chmpx%{?_isa} >= 1.0.105, k2htpdtor%{?_isa} >= 1.0.45, fuse
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.59, k2hash-devel >= 1.0.93, chmpx-devel >= 1.0.105, k2htpdtor >= 1.0.45, libyaml-devel, fuse, fuse-devel
+Requires: libfullock%{?_isa} >= @LIB_MINVER_LIBFULLOCK@, k2hash%{?_isa} >= @LIB_MINVER_LIBK2HASH@, chmpx%{?_isa} >= @LIB_MINVER_LIBCHMPX@, k2htpdtor%{?_isa} >= @LIB_MINVER_LIBK2HTPDTOR@, fuse
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= @LIB_MINVER_LIBFULLOCK@, k2hash-devel >= @LIB_MINVER_LIBK2HASH@, chmpx-devel >= @LIB_MINVER_LIBCHMPX@, k2htpdtor >= @LIB_MINVER_LIBK2HTPDTOR@, libyaml-devel, fuse, fuse-devel
 
 %description
 @LONGDESC@
@@ -82,18 +82,8 @@ find %{buildroot} -name '*.la' -exec rm -f {} ';'
 %postun -p /sbin/ldconfig
 %endif
 
-%if 0%{?rhel} == 6
-%clean
-rm -rf %{buildroot}
-%endif
-
 %files
-%if 0%{?rhel} == 6
-%doc COPYING
-%defattr(-,root,root)
-%else
 %license COPYING
-%endif
 %doc README AUTHORS ChangeLog
 %{_mandir}/man1/*
 %{_bindir}/*
@@ -103,16 +93,13 @@ rm -rf %{buildroot}
 #
 %package devel
 Summary: @SHORTDESC@ (development)
-Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.59, k2hash-devel%{?_isa} >= 1.0.93, chmpx-devel%{?_isa} >= 1.0.105, k2htpdtor%{?_isa} >= 1.0.45, libyaml-devel, fuse, fuse-devel
+Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= @LIB_MINVER_LIBFULLOCK@, k2hash-devel%{?_isa} >= @LIB_MINVER_LIBK2HASH@, chmpx-devel%{?_isa} >= @LIB_MINVER_LIBCHMPX@, k2htpdtor%{?_isa} >= @LIB_MINVER_LIBK2HTPDTOR@, libyaml-devel, fuse, fuse-devel
 
 %description devel
 Development package for building with @PACKAGE_NAME@ shared library.
 This package has header files and symbols for it.
 
 %files devel
-%if 0%{?rhel} == 6
-%defattr(-,root,root)
-%endif
 %doc README AUTHORS ChangeLog
 %{_includedir}/*
 

--- a/buildutils/make_description.sh
+++ b/buildutils/make_description.sh
@@ -97,8 +97,15 @@ while [ $# -ne 0 ]; do
 			exit 1
 		fi
 		IS_SHORT=0
-		ESC_LF_CHAR="\\n\\"
 		EXCLUSIVE_OPT=1
+		# [NOTE]
+		# I want to set ESC_LF_CHAR to "\n\".
+		# We can write as follows to set this, but to be compatible with vim and ShellCheck, so ex3 is used.
+		#	ex1) ESC_LF_CHAR="\\n\\"	-> vim will confuse it.
+		#	ex2) ESC_LF_CHAR='\n\'		-> ShellCheck will output a warning.
+		#	ex3) ESC_LF_CHAR='\n'\\		-> This is the correct.
+		#
+		ESC_LF_CHAR='\n'\\
 
 	elif [ "$1" = "-d" ] || [ "$1" = "-D" ] || [ "$1" = "--deblong" ] || [ "$1" = "--DEBLONG" ]; then
 		if [ "${EXCLUSIVE_OPT}" -eq 1 ]; then
@@ -136,7 +143,7 @@ done
 # indicate sections, so use them as markers to insert characters.
 # This allows you to see the section breaks.
 #
-if ! nroff -man "${MAN_FILE}" 2>/dev/null | col -b 2>/dev/null | sed -e 's/[0-9][0-9]*m//g' -e 's/^[[:space:]]/_____/g' >"${TEMP_FILE}" 2>/dev/null; then
+if ! nroff -man "${MAN_FILE}" 2>/dev/null | sed -e 's/[[:cntrl:]]\[[0-9][0-9]*m//g' -e 's/[[:cntrl:]][[:graph:]]//g' -e 's/^[[:space:]]/_____/g' >"${TEMP_FILE}" 2>/dev/null; then
 	echo "[ERROR] Could not read ${MAN_FILE} file with converting." 1>&2
 	echo "No description because the ${PRGNAME} program failed to extract the description."
 	rm -f "${TEMP_FILE}"
@@ -152,7 +159,7 @@ while IFS= read -r ONE_LINE; do
 	#
 	# revert inserted special chars.
 	#
-	REVERTED_LINE=$(echo "${ONE_LINE}" | sed -e 's/^_____//g' -e 's/^[[:space:]]*//g')
+	REVERTED_LINE=$(echo "${ONE_LINE}" | sed -e 's/^_____//g' -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g')
 
 	if [ "${LINE_LEVEL}" -eq 0 ]; then
 		if [ -n "${REVERTED_LINE}" ] && [ "${REVERTED_LINE}" = "NAME" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,14 @@ AC_PATH_PROG(PKG_CONFIG, pkg-config, [AC_MSG_RESULT(no)])
 AS_IF([test "$PKG_CONFIG" = "no"], [AC_MSG_ERROR(You have to install pkg-config to compile $PACKAGE_NAME v$PACKAGE_VERSION)])
 
 #
+# Version list for Libraries
+#
+AC_SUBST([LIB_MINVER_LIBK2HTPDTOR], "1.0.46")
+AC_SUBST([LIB_MINVER_LIBCHMPX], "1.0.106")
+AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.97")
+AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.61")
+
+#
 # Checking Libraries
 #
 check_depend_libs=1
@@ -158,9 +166,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.59], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.93], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.105], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.61], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.97], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.106], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # Checking FUSE Library

--- a/src/k2hftfuse.cc
+++ b/src/k2hftfuse.cc
@@ -466,6 +466,8 @@ static int h2htpfs_getattr(const char* path, struct stat* stbuf)
 	return 0;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterCallback
 static int h2htpfs_readlink(const char* path, char* buf, size_t size)
 {
 	return -EPERM;
@@ -718,6 +720,8 @@ static int h2htpfs_open(const char* path, struct fuse_file_info* fi)
 	return 0;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterCallback
 static int h2htpfs_read(const char* path, char* buf, size_t size, off_t offset, struct fuse_file_info* fi)
 {
 	// [NOTE]
@@ -826,6 +830,8 @@ static int h2htpfs_fsync(const char* path, int isdatasync, struct fuse_file_info
 	return 0;
 }
 
+// cppcheck-suppress unmatchedSuppression
+// cppcheck-suppress constParameterCallback
 static int h2htpfs_opendir(const char* path, struct fuse_file_info* fi)
 {
 	// All objects(directories and files) have same uid, gid and mode.

--- a/src/k2hftinfo.cc
+++ b/src/k2hftinfo.cc
@@ -2291,19 +2291,18 @@ bool K2hFtInfo::ReadDir(const char* path, k2hftldlist_t& list) const
 	}
 	list.clear();
 
-	PK2HFTLISTDIR	ptempld = NULL;
 	{
 		// "."
-		ptempld			= new K2HFTLISTDIR;
-		ptempld->strname= ".";
-		ptempld->pstat	= NULL;
-		list.push_back(ptempld);
+		PK2HFTLISTDIR ptempld1	= new K2HFTLISTDIR;
+		ptempld1->strname		= ".";
+		ptempld1->pstat			= NULL;
+		list.push_back(ptempld1);
 
 		// ".."
-		ptempld			= new K2HFTLISTDIR;
-		ptempld->strname= "..";
-		ptempld->pstat	= NULL;
-		list.push_back(ptempld);
+		PK2HFTLISTDIR ptempld2	= new K2HFTLISTDIR;
+		ptempld2->strname		= "..";
+		ptempld2->pstat			= NULL;
+		list.push_back(ptempld2);
 	}
 
 	// Lock
@@ -2361,7 +2360,7 @@ bool K2hFtInfo::ReadDir(const char* path, k2hftldlist_t& list) const
 		}
 
 		// set
-		ptempld						= new K2HFTLISTDIR;
+		PK2HFTLISTDIR ptempld		= new K2HFTLISTDIR;
 		ptempld->strname			= basename;
 		ptempld->pstat				= new (struct stat);
 

--- a/src/k2hftman.cc
+++ b/src/k2hftman.cc
@@ -108,8 +108,7 @@ void* K2hFtManage::TimeupWorkerProc(void* param)
 		// check all buffer & stacking
 		while(!fullock::flck_trylock_noshared_mutex(&(pFtMan->wstack_lockval)));	// LOCK
 		for(k2hftwbufmap_t::iterator iter = pFtMan->wbstackmap.begin(); iter != pFtMan->wbstackmap.end() && pFtMan->run_thread; ++iter){
-			uint64_t		filehandle	= iter->first;
-			K2hFtWriteBuff*	pwbuf		= iter->second;
+			K2hFtWriteBuff*	pwbuf = iter->second;
 
 			// check timeup
 			if(pwbuf && pwbuf->IsStackLimit()){
@@ -117,6 +116,7 @@ void* K2hFtManage::TimeupWorkerProc(void* param)
 				PK2HFTVALUE	pValue = pwbuf->Pop();
 				if(pValue){
 					// stacked
+					uint64_t	filehandle = iter->first;
 					valmap[filehandle] = pValue;
 				}
 			}

--- a/src/k2hftstructure.h
+++ b/src/k2hftstructure.h
@@ -169,6 +169,8 @@ inline PK2HFTVALUE BuildK2hFtValue(const k2hftlinelist_t& lines)
 
 	// set head
 	PK2HFTVALUE		pK2hFtVal	= reinterpret_cast<PK2HFTVALUE>(pBuff);
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress redundantInitialization
 	pK2hFtVal->head.bodylength	= totallen;
 	pK2hFtVal->head.linecount	= lines.size();
 
@@ -248,6 +250,8 @@ inline PK2HFTLINE BuildK2hFtLine(const unsigned char* data, size_t length, pid_t
 		return NULL;
 	}
 	PK2HFTLINE		pK2hFtLine	= reinterpret_cast<PK2HFTLINE>(pBuff);
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress redundantInitialization
 	pK2hFtLine->head.linelength	= length;
 	pK2hFtLine->head.pid		= pid;
 	get_local_hostname(pK2hFtLine->head.hostname);


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The supported operating systems have been changed as follows.
Other operating systems are not supported and packages will not be provided.
- ubuntu 20.04 (Focal Fossa)
- ubuntu 22.04 (Jammy Jellyfish)
- ubuntu 24.04 (Noble Numbat)  
- debian 11 (Bullseye)
- debian 12 (Bookworm)
- RockyLinux 8
- RockyLinux 9  
- Fedora 40
- Fedora 41  
- ALPINE 3.18
- ALPINE 3.19
- ALPINE 3.20  

In addition, the Docker images provided have been changed to the following two OS bases.
- Ubuntu 24.04
- ALPINE 3.20

In conjunction with this, we have corrected the related source code and bugs detected by the tool.