### PR TITLE
Avoided latest cppcheck error which maybe a false positive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -148,10 +148,10 @@ AS_IF([test "$PKG_CONFIG" = "no"], [AC_MSG_ERROR(You have to install pkg-config 
 #
 # Version list for Libraries
 #
-AC_SUBST([LIB_MINVER_LIBK2HTPDTOR], "1.0.46")
-AC_SUBST([LIB_MINVER_LIBCHMPX], "1.0.106")
-AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.97")
-AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.61")
+AC_SUBST([LIB_MINVER_LIBK2HTPDTOR], "1.0.48")
+AC_SUBST([LIB_MINVER_LIBCHMPX], "1.0.109")
+AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.99")
+AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.63")
 
 #
 # Checking Libraries
@@ -166,9 +166,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.61], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.97], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.106], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.63], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.99], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.109], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # Checking FUSE Library

--- a/src/k2hftutil.cc
+++ b/src/k2hftutil.cc
@@ -400,10 +400,18 @@ bool get_parent_dirpath(const char* path, string& parent)
 		ERR_K2HFTPRN("path(/) is mount point.");
 		return false;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress nullPointerOutOfMemory
 	char*	ptmp = strdup(path);
+
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress nullPointerOutOfMemory
 	if('/' == ptmp[strlen(ptmp) - 1]){
 		ptmp[strlen(ptmp) - 1] = '\0';
 	}
+
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress nullPointerOutOfMemory
 	char*	pos = strrchr(ptmp, '/');
 	if(!pos){
 		ERR_K2HFTPRN("path(%s) does not have /.", path);

--- a/src/k2hftwbuf.cc
+++ b/src/k2hftwbuf.cc
@@ -393,6 +393,8 @@ bool K2hFtWriteBuff::IsStackLimit(void)
 	if(0 == count){
 		result = false;
 	}else if(count <= K2hFtWriteBuff::StackLineMax){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress constVariablePointer
 		const PK2HFTLINE	pline = Stack.front();
 		if(pline && time(NULL) <= (pline->head.ts.tv_sec + K2hFtWriteBuff::StackTimeup)){
 			result = false;


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The latest cppcheck(v2.11 or 2.14 or later) is falsely detecting a `nullPointerOutOfMemory` error when specifying `const` using the typedef name of a structure pointer.
Therefore, avoided this by adding an inline suppress.